### PR TITLE
add: github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  # Enable version updates for npm
+  - package-ecosystem: "npm"
+    # Look for `package.json` and `pnpm-lock.yaml` files in the root directory
+    directory: "/"
+    # Check the npm registry for updates every day (you can choose your own schedule)
+    schedule:
+      interval: "daily"
+  # Lerna-specific configuration
+  - package-ecosystem: "npm"
+    # Assuming Lerna packages are in the 'packages' directory, adjust if different
+    directory: "/packages/*"
+    schedule:
+      interval: "daily"
+    # Additional configuration for monorepos
+    allow:
+      # Allow updates to devDependencies, runtime dependencies, etc.
+      - dependency-type: "all"

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,63 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Documentation: https://github.com/apps/settings
+
+repository:
+  # Repository name
+  name: mdl-js  
+  description:
+    process MDOC CBOR according to ISO 18013-5.
+  # A URL with more information about the repository
+  # homepage:
+  # A comma-separated list of topics to set on the repository
+  topics: mdl, mdoc
+  default_branch: main
+
+# Labels: define labels for Issues and Pull Requests
+labels:
+  - name: bug
+    color: CC0000
+    description: An issue with the system 🐛.
+
+  - name: feature
+    # If including a `#`, make sure to wrap it with quotes!
+    color: '#336699'
+    description: New functionality.
+
+  - name: Help Wanted
+    # Provide a new name to rename an existing label
+    new_name: first-timers-only
+
+branches:
+  - name: next
+    protection:
+      # Required. Require at least one approving review on a pull request, before merging. Set to null to disable.
+      required_pull_request_reviews:
+        # The number of approvals required. (1-6)
+        required_approving_review_count: 1
+        # Dismiss approved reviews automatically when a new commit is pushed.
+        dismiss_stale_reviews: true
+      required_status_checks:
+        # Required. Require branches to be up to date before merging.
+        strict: true
+        # Required. The list of status checks to require in order to merge into this branch
+        contexts: []
+      # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
+      enforce_admins: true
+  - name: main
+    protection:
+      # Required. Require at least one approving review on a pull request, before merging. Set to null to disable.
+      required_pull_request_reviews:
+        # The number of approvals required. (1-6)
+        required_approving_review_count: 1
+        # Dismiss approved reviews automatically when a new commit is pushed.
+        dismiss_stale_reviews: true
+      required_status_checks:
+        # Required. Require branches to be up to date before merging.
+        strict: true
+        # Required. The list of status checks to require in order to merge into this branch
+        contexts: []
+      # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
+      enforce_admins: true

--- a/.github/workflows/build-test-publish-on-push-cached.yaml
+++ b/.github/workflows/build-test-publish-on-push-cached.yaml
@@ -1,0 +1,166 @@
+name: build-test-publish-on-push-cached
+on:
+  pull_request:
+    branches:
+      - 'master'
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 9
+      - run: pnpm add -g pnpm
+      - name: 'Setup Node.js with pnpm cache'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - run: pnpm install
+      - run: pnpm build
+      - name: 'Save build output'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}
+          key: ${{ runner.os }}-build-${{ github.sha }}-${{ github.run_id }}
+
+  test:
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ['18.x', '20.x']
+    steps:
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 9
+      - run: pnpm add -g pnpm
+      - name: 'Restore build output'
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}
+          key: ${{ runner.os }}-build-${{ github.sha }}-${{ github.run_id }}
+          restore-keys: ${{ runner.os }}-build-${{ github.sha }}
+          fail-on-cache-miss: true
+      - name: 'Setup Node.js with pnpm cache'
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
+      - name: 'Run node'
+        run: pnpm test
+      - uses: actions/upload-artifact@v4
+        # we are only uploading the 20 coverage report so we do not have to merge them in the next step.
+        if: matrix.node-version == '20.x'
+        with:
+          name: coverage-artifacts
+          path: coverage/
+
+  report-coverage:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/download-artifact@v4
+        with:
+          name: coverage-artifacts
+          path: coverage
+      - uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  lint:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 9
+      - run: pnpm add -g pnpm
+      - name: 'Restore build output'
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}
+          key: ${{ runner.os }}-build-${{ github.sha }}-${{ github.run_id }}
+          restore-keys: ${{ runner.os }}-build-${{ github.sha }}
+          fail-on-cache-miss: true
+      - name: 'Setup Node.js with pnpm cache'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+        # we are not using the github action for biome, but the package.json script. this makes sure we are using the same versions.
+      - name: Run Biome      
+        run: pnpm run biome:ci
+
+  # Only run this job when the push is on main
+  publish:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # needs permissions to write tags to the repository
+    permissions:
+      contents: write
+    needs:
+      - build
+      - test
+      - lint
+    env:
+      NPM_TOKEN: ${{secrets.NPM_TOKEN }}
+      NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN }}
+      GH_TOKEN: ${{secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN }}
+      GH_USER: github-actions
+      GH_EMAIL: github-actions@github.com
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{secrets.GITHUB_TOKEN }}
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 9
+      - run: pnpm add -g pnpm
+      - name: 'Setup Node.js with pnpm cache'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: 'Restore build output'
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}
+          key: ${{ runner.os }}-build-${{ github.sha }}-${{ github.run_id }}
+          restore-keys: ${{ runner.os }}-build-${{ github.sha }}
+          fail-on-cache-miss: true
+
+      - name: 'Setup git coordinates'
+        run: |
+          git remote set-url origin https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{ github.repository }}.git
+          git config user.name $GH_USER
+          git config user.email $GH_EMAIL
+
+      - name: 'Setup npm registry'
+        run: |
+          echo "@m-doct:registry=https://registry.npmjs.org/" > .npmrc
+          echo "registry=https://registry.npmjs.org/" >> .npmrc
+          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> .npmrc
+          npm whoami
+
+      - name: 'Publish next version'
+        run: pnpm publish:next

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,185 @@
+name: release
+on:
+  workflow_dispatch:
+
+jobs:
+  check-author:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        
+      - name: Check if user is in CODEOWNERS
+        id: check_user
+        run: |
+            CODEOWNERS_PATH="CODEOWNERS"
+            if [ ! -f "$CODEOWNERS_PATH" ]; then
+                echo "CODEOWNERS file not found."
+                exit 1            
+            fi
+            
+            # Extract GitHub usernames from CODEOWNERS file (assumes usernames, not emails or teams)
+            USERS=$(grep '@' $CODEOWNERS_PATH | sed -E 's/.*@([^ ]+).*/\1/' | tr '\n' ' ')
+            
+            # Check if the actor is in the list of users
+            if [[ ! " $USERS " =~ " ${{ github.actor }} " ]]; then
+                echo "Error: Actor ${{ github.actor }} is not listed in CODEOWNERS."
+                exit 1
+            else
+                echo "Actor ${{ github.actor }} is listed in CODEOWNERS."
+            fi
+  # we can add an approval stage with the environment so it can only be run when accepted by two authorized users.
+  build:
+    needs: check-author
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 9
+      - run: pnpm add -g pnpm
+      - name: 'Setup Node.js with pnpm cache'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - run: pnpm install
+      - run: pnpm build
+      - name: 'Save build output'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}
+          key: ${{ runner.os }}-build-${{ github.sha }}-${{ github.run_id }}
+
+  test:
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ['18.x', '20.x']
+    steps:
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 9
+      - run: pnpm add -g pnpm
+      - name: 'Restore build output'
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}
+          key: ${{ runner.os }}-build-${{ github.sha }}-${{ github.run_id }}
+          restore-keys: ${{ runner.os }}-build-${{ github.sha }}
+          fail-on-cache-miss: true
+      - name: 'Setup Node.js with pnpm cache'
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
+      - name: 'Run node'
+        run: pnpm test
+      - uses: actions/upload-artifact@v4
+        # we are only uploading the 20 coverage report so we do not have to merge them in the next step.
+        if: matrix.node-version == '20.x'
+        with:
+          name: coverage-artifacts
+          path: coverage/
+
+  report-coverage:
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/download-artifact@v4
+        with:
+          name: coverage-artifacts
+          path: coverage
+      - uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  lint:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 9
+      - run: pnpm add -g pnpm
+      - name: 'Restore build output'
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}
+          key: ${{ runner.os }}-build-${{ github.sha }}-${{ github.run_id }}
+          restore-keys: ${{ runner.os }}-build-${{ github.sha }}
+          fail-on-cache-miss: true
+      - name: 'Setup Node.js with pnpm cache'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+        # we are not using the github action for biome, but the package.json script. this makes sure we are using the same versions.
+      - name: Run Biome      
+        run: pnpm run biome:ci
+
+  publish:    
+    # needs permissions to write tags to the repository
+    permissions:
+      contents: write
+    needs:
+      - build
+      - test
+      - lint
+    env:
+      NPM_TOKEN: ${{secrets.NPM_TOKEN }}
+      NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN }}
+      GH_TOKEN: ${{secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN }}
+      GH_USER: github-actions
+      GH_EMAIL: github-actions@github.com
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{secrets.GITHUB_TOKEN }}
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 9
+      - run: pnpm add -g pnpm
+      - name: 'Setup Node.js with pnpm cache'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: 'Restore build output'
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}
+          key: ${{ runner.os }}-build-${{ github.sha }}-${{ github.run_id }}
+          restore-keys: ${{ runner.os }}-build-${{ github.sha }}
+          fail-on-cache-miss: true
+
+      - name: 'Setup git coordinates'
+        run: |
+          git remote set-url origin https://${{github.actor}}:${{secrets.TOKEN}}@github.com/${{ github.repository }}.git
+          git config user.name $GH_USER
+          git config user.email $GH_EMAIL
+
+      - name: 'Setup npm registry'
+        run: |
+          echo "@m-doc:registry=https://registry.npmjs.org/" > .npmrc
+          echo "registry=https://registry.npmjs.org/" >> .npmrc
+          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> .npmrc
+          npm whoami
+
+      - name: 'Publish latest version'        
+        run: pnpm publish:latest


### PR DESCRIPTION
Fixes #2

This PR will use the same github actions used in https://github.com/openwallet-foundation-labs/sd-jwt-js

The following secrets need to be set to run this:
- NPM_TOKEN: token to deploy to npmjs
- CODECOV_TOKEN:  token to upload the coverage report to codecov (and to not hit the rate limits)

This actions are configured for the master branch, since this is the current primary branch

Signed-off-by: Mirko Mollik <mollik@trustcerts.de>